### PR TITLE
Removing rules from the manifest will now remove them from the VM

### DIFF
--- a/jobs/port_forwarding/templates/bin/forward_ports.sh.erb
+++ b/jobs/port_forwarding/templates/bin/forward_ports.sh.erb
@@ -1,4 +1,28 @@
+#!/bin/bash
+
+CHAIN="portforwarding-boshrelease"
+
+function forward_exists {
+	set -e
+	chain=$1
+	iptables -t nat -C ${chain} -j ${CHAIN} 2>/dev/null
+}
+
+if ! iptables -t nat -L ${CHAIN} >/dev/null 2>&1; then
+	iptables -t nat -N ${CHAIN}
+fi
+
+# if rule doesnt exists in prerouting, add it
+if forward_exists PREROUTING; then
+	iptables -t nat -A PREROUTING -j ${CHAIN}
+fi
+
+# if rule doesnt exist in output, add it
+if forward_exists OUTPUT; then
+	iptables -t nat -A OUTPUT -j ${CHAIN}
+fi
+
+
 <% p("port_forwarding.rules").each do |rule| %>
-sudo iptables -t nat -A PREROUTING -p tcp -d <%= spec.networks.send(spec.networks.methods(false).first).ip %> --dport <%= rule['external_port'] %> -j DNAT --to <%= rule['internal_ip'] %>:<%= rule['internal_port'] %>
-sudo iptables -t nat -A OUTPUT -p tcp -d <%= spec.networks.send(spec.networks.methods(false).first).ip %> --dport <%= rule['external_port'] %> -j DNAT --to <%= rule['internal_ip'] %>:<%= rule['internal_port'] %>
+sudo iptables -t nat -A portforwarding-release -p tcp -d <%= spec.networks.send(spec.networks.methods(false).first).ip %> --dport <%= rule['external_port'] %> -j DNAT --to <%= rule['internal_ip'] %>:<%= rule['internal_port'] %>
 <% end %>

--- a/jobs/port_forwarding/templates/bin/unforward_ports.sh.erb
+++ b/jobs/port_forwarding/templates/bin/unforward_ports.sh.erb
@@ -1,4 +1,3 @@
-<% p("port_forwarding.rules").each do |rule| %>
-sudo iptables -t nat -D PREROUTING -p tcp -d <%= spec.networks.send(spec.networks.methods(false).first).ip %> --dport <%= rule['external_port'] %> -j DNAT --to <%= rule['internal_ip'] %>:<%= rule['internal_port'] %>
-sudo iptables -t nat -D OUTPUT -p tcp -d <%= spec.networks.send(spec.networks.methods(false).first).ip %> --dport <%= rule['external_port'] %> -j DNAT --to <%= rule['internal_ip'] %>:<%= rule['internal_port'] %>
-<% end %>
+#!/bin/bash
+
+iptables -t nat -F portforwarding-release


### PR DESCRIPTION
Previously, BOSH would update the unforward script prior to running
it, which causes any removed/changed rules to stay present, while new
rules are appended. Removal/cleanup was either manual, or done by
recreating the VM.

This change migrates the rules to exist in their own table, that can
be flushed every time. PREROUTING + OUTPUT chains are linked to this via
jumps, if they do not already exist.
